### PR TITLE
Update README.md, Changed how venv is activated

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ SOD Spreadsheets/
 2. **Create Virtual Environment**
    ```bash
    python3 -m venv venv
-   venv\Scripts\activate
+   source venv\bin\activate
    ```
 
 3. **Install Dependencies**


### PR DESCRIPTION
I have never seen a venv/Scripts folder, is this something I am just unfamiliar with?

I ran through the install now and had to use
$ source venv/bin/activate

So I suggest that as a change.