### PR TITLE
Enable sorting property on Tree View

### DIFF
--- a/kanvas.py
+++ b/kanvas.py
@@ -156,6 +156,7 @@ class MainApp:
     
     def connect_ui_elements(self):
         self.tree_view = self.window.ui.treeViewMain
+        self.tree_view.setSortingEnabled(True)
         if self.tree_view:
             self.tree_view.doubleClicked.connect(self.edit_row)
         else:
@@ -1377,4 +1378,5 @@ class MainApp:
 
 if __name__ == "__main__":
     main_app = MainApp()
+
     sys.exit(main_app.run())


### PR DESCRIPTION
I'm not an expert in QT but it looks like the Tree View class has a property called setSortingEnabled that turns on sorting by clicking on headers. Might not be a permanent solution as the SOD is not sorted but could provide a quick quality of life improvement. (This is my first pull request, so let me know if I am doing it incorrectly)
https://doc.qt.io/qt-6/qtreeview.html#sortingEnabled-prop